### PR TITLE
Bugfix for game not populating pawn's color correctly

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,5 +1,5 @@
 class Pawn < Piece
-  attr_accessor :on_initial_square, :color
+  attr_accessor :on_initial_square
   
 
   def valid_move?(x,y)


### PR DESCRIPTION
Removed :color attr-accessor from pawn.rb
Fixes [#61]